### PR TITLE
feat: load from daily page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
+      # run linting!
+      - run: npm run lint
+
       # run tests!
       - run: npm t
 

--- a/fixtures/parsed-menu-content.json
+++ b/fixtures/parsed-menu-content.json
@@ -7,7 +7,8 @@
       "subsections": {
         "sides": ["Chips, peas & mushy peas"]
       },
-      "title": "From the Oven"
+      "title": "From the Oven",
+      "color": "#C41017"
     },
     {
       "body": [
@@ -16,19 +17,22 @@
         "served with red onion freekeh, toasted hazelnut and lemon dressing"
       ],
       "subsections": {},
-      "title": "Healthy Bar"
+      "title": "Healthy Bar",
+      "color": "#007404"
     },
     {
       "body": ["Chilli glazed chicken, wild rice and red pepper"],
       "subsections": {
         "sides": ["Glazed sugar snaps and broccoli"]
       },
-      "title": "Chefs Theatre"
+      "title": "Chefs Theatre",
+      "color": "#00BFFF"
     },
     {
       "body": ["Roasted parsnip (v)", "Curried cauliflower and bacon"],
       "subsections": {},
-      "title": "Soup"
+      "title": "Soup",
+      "color": "#e6e600"
     }
   ],
   "cafeMenuContent": [
@@ -37,14 +41,16 @@
         "breakfast": ["Smoked bacon frittata"],
         "lunch": ["Roasted aubergine and Parma ham on focaccia"]
       },
-      "title": "monday"
+      "title": "monday",
+      "color": "#3126A2"
     },
     {
       "subsections": {
         "breakfast": ["Pork and Beans"],
         "lunch": ["Fried egg and instant noodles"]
       },
-      "title": "tuesday"
+      "title": "tuesday",
+      "color": "#3126A2"
     }
   ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
   // collectCoverageFrom: null,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
@@ -124,7 +124,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: 'node',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "menu-lambda",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "test": "jest",
+    "lint": "eslint . --report-unused-disable-directives",
     "start": "node dry-run",
     "invoke": "./scripts/invoke-local.sh",
     "deploy": "serverless deploy -v"

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,12 @@ functions:
           input:
             slackUrl: ${env:SLACK_URL_PRESEND}
       - schedule:
+          name: presend-morning-test-2
+          enabled: true
+          rate: cron(15 8 ? * 2-6 *)
+          input:
+            slackUrl: ${env:SLACK_URL_PRESEND}
+      - schedule:
           name: send-morning
           enabled: true
           rate: cron(30 8 ? * 2-6 *)

--- a/src/__snapshots__/slack.spec.js.snap
+++ b/src/__snapshots__/slack.spec.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/slack.js buildPayload should return a snapshot match 1`] = `
+exports[`src/slack.js buildPayload with canteen and cafe data should return a snapshot match 1`] = `
 Object {
   "attachments": Array [
     Object {
-      "color": undefined,
+      "color": "#C41017",
       "mrkdwn_in": Array [
         "text",
       ],
@@ -13,7 +13,7 @@ Sides: chips, peas & mushy peas",
       "title": "From the Oven",
     },
     Object {
-      "color": undefined,
+      "color": "#007404",
       "mrkdwn_in": Array [
         "text",
       ],
@@ -23,7 +23,7 @@ Served with red onion freekeh, toasted hazelnut and lemon dressing",
       "title": "Healthy Bar",
     },
     Object {
-      "color": undefined,
+      "color": "#00BFFF",
       "mrkdwn_in": Array [
         "text",
       ],
@@ -32,7 +32,7 @@ Sides: glazed sugar snaps and broccoli",
       "title": "Chefs Theatre",
     },
     Object {
-      "color": undefined,
+      "color": "#e6e600",
       "mrkdwn_in": Array [
         "text",
       ],
@@ -41,13 +41,64 @@ Curried cauliflower and bacon",
       "title": "Soup",
     },
     Object {
-      "color": undefined,
+      "color": "#3126A2",
       "mrkdwn_in": Array [
         "text",
       ],
       "text": "Breakfast: smoked bacon frittata
 Lunch: roasted aubergine and parma ham on focaccia",
       "title": "Café",
+    },
+    Object {
+      "text": "Menu taken from <https://the-canteen-url.com#canteen|Canteen on 14 website>.
+Menu Lambda 1.33.7. Any issues or suggestions? <https://the-bugs-url.com|Post on the GitHub!>",
+    },
+  ],
+  "icon_emoji": ":hamburger:",
+  "text": "Menu for Friday, February 1, 2019",
+  "username": "Canteen on 14",
+}
+`;
+
+exports[`src/slack.js buildPayload with no cafe content should return a snapshot match 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "color": "#C41017",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Genuine chip shop - battered pollock & battered sausages, savaloys
+Sides: chips, peas & mushy peas",
+      "title": "From the Oven",
+    },
+    Object {
+      "color": "#007404",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Pulled jack fruit
+Freshly baked salmon
+Served with red onion freekeh, toasted hazelnut and lemon dressing",
+      "title": "Healthy Bar",
+    },
+    Object {
+      "color": "#00BFFF",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Chilli glazed chicken, wild rice and red pepper
+Sides: glazed sugar snaps and broccoli",
+      "title": "Chefs Theatre",
+    },
+    Object {
+      "color": "#e6e600",
+      "mrkdwn_in": Array [
+        "text",
+      ],
+      "text": "Roasted parsnip (v)
+Curried cauliflower and bacon",
+      "title": "Soup",
     },
     Object {
       "text": "Menu taken from <https://the-canteen-url.com#canteen|Canteen on 14 website>.

--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,17 @@ const got = require('got');
 const { getContent } = require('./get-content');
 const { buildPayload } = require('./slack');
 
-const run = slackUrl =>
-  getContent()
-    .then(content => buildPayload(new Date(), content))
+const run = (slackUrl, date = new Date()) =>
+  getContent(date)
+    .then(content => buildPayload(date, content))
     .then(payload => {
       console.log('Posting payload:', JSON.stringify(payload, null, 2));
       return got(slackUrl, { method: 'POST', body: JSON.stringify(payload) });
     });
 
-const test = () =>
-  getContent()
-    .then(content => buildPayload(new Date(), content))
+const test = (date = new Date()) =>
+  getContent(date)
+    .then(content => buildPayload(date, content))
     .then(payload => {
       console.log(
         'Slack payload (not posting):',

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,34 @@
 /* eslint-disable no-console */
 const got = require('got');
 
+const { isWeekend } = require('./utils');
 const { getContent } = require('./get-content');
 const { buildPayload } = require('./slack');
 
+const getPayload = date => {
+  if (isWeekend(date)) {
+    return Promise.reject(
+      new Error(
+        'Provided date is a weekend. Weekend menus not currently supported.',
+      ),
+    );
+  }
+  return getContent(date).then(content => buildPayload(date, content));
+};
+
 const run = (slackUrl, date = new Date()) =>
-  getContent(date)
-    .then(content => buildPayload(date, content))
-    .then(payload => {
-      console.log('Posting payload:', JSON.stringify(payload, null, 2));
-      return got(slackUrl, { method: 'POST', body: JSON.stringify(payload) });
-    });
+  getPayload(date).then(payload => {
+    console.log('Posting payload:', JSON.stringify(payload, null, 2));
+    return got(slackUrl, { method: 'POST', body: JSON.stringify(payload) });
+  });
 
 const test = (date = new Date()) =>
-  getContent(date)
-    .then(content => buildPayload(date, content))
-    .then(payload => {
-      console.log(
-        'Slack payload (not posting):',
-        JSON.stringify(payload, null, 2),
-      );
-    });
+  getPayload(date).then(payload => {
+    console.log(
+      'Slack payload (not posting):',
+      JSON.stringify(payload, null, 2),
+    );
+  });
 
 module.exports = {
   run,

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -77,6 +77,7 @@ const createParser = ({
         // We've hit a section title so add the new section to the list.
         acc.push(newSection);
       } else if (
+        currentSection &&
         lineIsAnOrBreak &&
         getSubsection(SUBSECTION_MATCHERS, lines[i - 1])
       ) {

--- a/src/slack.js
+++ b/src/slack.js
@@ -12,36 +12,41 @@ const formatSubsection = (key, content) => `${sentenceCase(key)}: ${content}`;
 
 // Format the menu content as a Slack web hook post payload.
 const buildPayload = (date, { mainMenuContent, cafeMenuContent }) => {
+  // For cafe, the section titles are days of the week.
   const day = getDay(date);
+  const todaysCafeMenuContent = cafeMenuContent.find(x => x.title === day);
+
   const payloadContent = [
     ...mainMenuContent,
-    {
-      // For cafe, the section names are days of the week, so we get todays one and rename the title.
-      ...cafeMenuContent.find(x => x.title === day),
+    todaysCafeMenuContent && {
+      // Don't want the day as the title, so override it.
+      ...todaysCafeMenuContent,
       title: 'Café',
     },
-  ].map(section => {
-    // For each section, we want to generate the lines of text.
-    // First the main body content (if any), then each subsection text.
-    const lines = [];
-    if (section.body) {
-      lines.push(...section.body);
-    }
-    lines.push(
-      ...Object.keys(section.subsections).reduce((acc, key) => {
-        acc.push(formatSubsection(key, section.subsections[key]));
-        return acc;
-      }, []),
-    );
+  ]
+    .filter(Boolean)
+    .map(section => {
+      // For each section, we want to generate the lines of text.
+      // First the main body content (if any), then each subsection text.
+      const lines = [];
+      if (section.body) {
+        lines.push(...section.body);
+      }
+      lines.push(
+        ...Object.keys(section.subsections).reduce((acc, key) => {
+          acc.push(formatSubsection(key, section.subsections[key]));
+          return acc;
+        }, []),
+      );
 
-    // Each section output as a Slack attachment object (these will be sent as part of payload).
-    return {
-      title: section.title,
-      color: section.color,
-      text: lines.map(line => sentenceCase(line)).join('\n'),
-      mrkdwn_in: ['text'],
-    };
-  });
+      // Each section output as a Slack attachment object (these will be sent as part of payload).
+      return {
+        title: section.title,
+        color: section.color,
+        text: lines.map(line => sentenceCase(line)).join('\n'),
+        mrkdwn_in: ['text'],
+      };
+    });
 
   const payload = {
     username: 'Canteen on 14',

--- a/src/slack.spec.js
+++ b/src/slack.spec.js
@@ -2,12 +2,8 @@ const fixture = require('../fixtures/parsed-menu-content');
 
 describe('src/slack.js', () => {
   describe('buildPayload', () => {
-    let data;
-    let mocks;
-    let result;
-
-    beforeAll(() => {
-      data = {
+    const setup = ({ day } = {}) => {
+      const data = {
         date: new Date('2019-02-01'),
         menuContent: fixture,
         pkgVersion: '1.33.7',
@@ -15,8 +11,8 @@ describe('src/slack.js', () => {
         canteenUrl: 'https://the-canteen-url.com',
       };
 
-      mocks = {
-        getDay: jest.fn(() => 'monday'),
+      const mocks = {
+        getDay: jest.fn(() => day),
       };
 
       jest.doMock('../package.json', () => ({
@@ -36,11 +32,41 @@ describe('src/slack.js', () => {
 
       // eslint-disable-next-line global-require
       const { buildPayload } = require.requireActual('./slack');
-      result = buildPayload(data.date, data.menuContent);
+      const result = buildPayload(data.date, data.menuContent);
+
+      return {
+        data,
+        mocks,
+        result,
+      };
+    };
+
+    describe('with canteen and cafe data', () => {
+      let result;
+
+      beforeAll(() => {
+        ({ result } = setup({ day: 'monday' }));
+      });
+
+      afterAll(() => jest.resetModules());
+
+      it('should return a snapshot match', () => {
+        expect(result).toMatchSnapshot();
+      });
     });
 
-    it('should return a snapshot match', () => {
-      expect(result).toMatchSnapshot();
+    describe('with no cafe content', () => {
+      let result;
+
+      beforeAll(() => {
+        ({ result } = setup({ day: 'saturday' }));
+      });
+
+      afterAll(() => jest.resetModules());
+
+      it('should return a snapshot match', () => {
+        expect(result).toMatchSnapshot();
+      });
     });
   });
 });

--- a/src/slack.spec.js
+++ b/src/slack.spec.js
@@ -30,7 +30,6 @@ describe('src/slack.js', () => {
         getDay: mocks.getDay,
       }));
 
-      // eslint-disable-next-line global-require
       const { buildPayload } = require.requireActual('./slack');
       const result = buildPayload(data.date, data.menuContent);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,4 +12,6 @@ const getDay = date => {
   return days[date.getDay()];
 };
 
-module.exports = { getDay };
+const isWeekend = date => ['saturday', 'sunday'].includes(getDay(date));
+
+module.exports = { getDay, isWeekend };

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,4 +1,4 @@
-const { getDay } = require('./utils');
+const { getDay, isWeekend } = require('./utils');
 
 describe('src/utils.js', () => {
   describe('getDay', () => {
@@ -28,6 +28,36 @@ describe('src/utils.js', () => {
 
     it('should return "sunday"', () => {
       expect(getDay(new Date('2019-02-10'))).toEqual('sunday');
+    });
+  });
+
+  describe('isWeekend', () => {
+    it('should return false for monday', () => {
+      expect(isWeekend(new Date('2019-02-04'))).toBe(false);
+    });
+
+    it('should return false for tuesday', () => {
+      expect(isWeekend(new Date('2019-02-05'))).toBe(false);
+    });
+
+    it('should return false for wednesday', () => {
+      expect(isWeekend(new Date('2019-02-06'))).toBe(false);
+    });
+
+    it('should return false for thursday', () => {
+      expect(isWeekend(new Date('2019-02-07'))).toBe(false);
+    });
+
+    it('should return false for friday', () => {
+      expect(isWeekend(new Date('2019-02-08'))).toBe(false);
+    });
+
+    it('should return true for saturday', () => {
+      expect(isWeekend(new Date('2019-02-09'))).toBe(true);
+    });
+
+    it('should return true for sunday', () => {
+      expect(isWeekend(new Date('2019-02-10'))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
- load main menu from daily page (/canteen-monday e.t.c.) as this should reduce instances of homepage not being updated in time.
- add second presend (to test Slack channel) at 8:15 for final check page is updated.
- add linting run to build pipeline.
- added error when running on weekend.